### PR TITLE
Investigate missing Supabase user data

### DIFF
--- a/frontend/APIConfig.swift
+++ b/frontend/APIConfig.swift
@@ -10,10 +10,10 @@ struct APIConfig {
     
     // MARK: - API Endpoints
     static let endpoints = [
-        "register": "/api/users/register",
-        "login": "/api/users/login",
-        "logout": "/api/users/logout",
-        "profile": "/api/users/profile",
+        "register": "/api/register",
+        "login": "/api/login",
+        "logout": "/api/logout",
+        "profile": "/api/me",
         "createDispute": "/api/disputes/create",
         "getDisputes": "/api/disputes/user",
         "joinDispute": "/api/disputes/join",


### PR DESCRIPTION
Update frontend API endpoint paths to match backend routes.

The previous paths for authentication and profile endpoints (e.g., `/api/users/register`) were causing "Not Found" or "Method Not Allowed" errors because the backend expects shorter paths (e.g., `/api/register`). This change aligns the frontend calls with the backend's actual exposed routes.