### PR TITLE
Fix jwt token access in auth service

### DIFF
--- a/frontend/mockauthservice.swift
+++ b/frontend/mockauthservice.swift
@@ -20,6 +20,25 @@ class MockAuthService: ObservableObject {
     private let userDefaults = UserDefaults.standard
     private let userKey = "mediationAI_currentUser"
     private let tokenKey = "mediationAI_access_token"
+
+    // Expose the stored JWT / access token so that views and services can conveniently read it.
+    // We don’t mark this as `@Published` because UI does not need to reactively refresh when the
+    // token changes – it’s only accessed on demand when performing network requests. Using a
+    // computed property avoids having to keep the value in sync manually; it simply proxies to
+    // `UserDefaults` where the token is already stored.
+    /// The JWT / access token that was persisted after signing-in or signing-up. Returns `nil` when the
+    /// user is signed-out or no token has been saved yet.
+    var jwtToken: String? {
+        get { userDefaults.string(forKey: tokenKey) }
+        set {
+            if let value = newValue {
+                userDefaults.set(value, forKey: tokenKey)
+            } else {
+                userDefaults.removeObject(forKey: tokenKey)
+            }
+        }
+    }
+    
     private let faceIDKey = "mediationAI_faceID_enabled"
     private let autoLoginKey = "mediationAI_autoLogin_enabled"
     


### PR DESCRIPTION
Add `jwtToken` property to `MockAuthService` to resolve compilation errors.

The `MockAuthService` was missing a direct `jwtToken` property, causing compilation errors when attempting to access it (e.g., 'no dynamic member jwtToken'). This PR adds a computed `jwtToken` property that proxies the value from `UserDefaults`, resolving these issues.

---

[Open in Web](https://cursor.com/agents?id=bc-3c6c3f93-d7d6-4986-812b-842c6bb1ba61) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3c6c3f93-d7d6-4986-812b-842c6bb1ba61)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)