### PR TITLE
Debug missing social api service environment object

### DIFF
--- a/frontend/MainTabView.swift
+++ b/frontend/MainTabView.swift
@@ -44,5 +44,6 @@ struct MainTabView_Previews: PreviewProvider {
         MainTabView()
             .environmentObject(MockAuthService())
             .environmentObject(MockDisputeService())
+            .environmentObject(SocialAPIService())
     }
 }

--- a/frontend/MediationAIApp.swift
+++ b/frontend/MediationAIApp.swift
@@ -16,6 +16,7 @@ struct MediationAIApp: App {
     @StateObject var purchaseService = InAppPurchaseService()
     @StateObject var badgeService = BadgeService()
     @StateObject var viralService = ViralAPIService.shared
+    @StateObject var socialService = SocialAPIService()
 
     
     var body: some Scene {
@@ -26,6 +27,7 @@ struct MediationAIApp: App {
                 .environmentObject(purchaseService)
                 .environmentObject(badgeService)
                 .environmentObject(viralService)
+                .environmentObject(socialService)
         }
     }
 }


### PR DESCRIPTION
Inject `SocialAPIService` as an environment object to resolve runtime crash.

The app was crashing at runtime with "No ObservableObject of type SocialAPIService found" because views using `@EnvironmentObject var social: SocialAPIService` could not find an instance in the view hierarchy. This PR adds `SocialAPIService` as an `@StateObject` in `MediationAIApp` and injects it into the `WindowGroup`, and also provides it for `MainTabView_Previews` to prevent preview crashes.

---

[Open in Web](https://cursor.com/agents?id=bc-d7ca14e0-960d-4fc5-845a-bec76e31aa26) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d7ca14e0-960d-4fc5-845a-bec76e31aa26)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)