### PR TITLE
Fix glitch in following section

### DIFF
--- a/frontend/LiveFeedView.swift
+++ b/frontend/LiveFeedView.swift
@@ -50,6 +50,13 @@ struct LiveFeedView: View {
                 }
             }
         }
+        // Keep local feed arrays in sync with latest data from the service
+        .onReceive(socialService.$liveClashes) { clashes in
+            exploreFeed = clashes
+        }
+        .onReceive(socialService.$followingClashes) { clashes in
+            followingFeed = clashes
+        }
         .onAppear { loadTab(tab) }
         .onChange(of: tab) { idx in loadTab(idx) }
     }


### PR DESCRIPTION
Add `onReceive` listeners to `LiveFeedView` to prevent UI glitches when switching between Explore and Following feeds.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e721e45-81aa-45fe-9bb1-131d06afc897">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e721e45-81aa-45fe-9bb1-131d06afc897">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>